### PR TITLE
Move the init code to the initialize methods

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,7 @@
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UnifiedLogger">
         <param name="android-package" value="edu.berkeley.eecs.emission.cordova.unifiedlogger.UnifiedLogger"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 
@@ -45,6 +46,7 @@
     <config-file target="config.xml" parent="/*">
       <feature name="UnifiedLogger">
         <param name="ios-package" value="BEMUnifiedLogger" />
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 

--- a/src/android/UnifiedLogger.java
+++ b/src/android/UnifiedLogger.java
@@ -10,6 +10,10 @@ import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 
 public class UnifiedLogger extends CordovaPlugin {
 
+    protected void pluginInitialize() {
+        Log.log(cordova.getActivity(), "INFO", "UnifiedLogger", "finished init of android native code");
+    }
+
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
         if (action.equals("log")) {

--- a/src/ios/BEMUnifiedLogger.m
+++ b/src/ios/BEMUnifiedLogger.m
@@ -3,6 +3,15 @@
 
 @implementation BEMUnifiedLogger
 
+- (void)pluginInitialize
+{
+    // TODO: We should consider adding a create statement to the init, similar
+    // to android - then it doesn't matter if the pre-populated database is not
+    // copied over.
+    NSLog(@"UnifiedLogger:pluginInitialize singleton -> initialize native DB");
+    [[DBLogging database] log:@"finished init of iOS native code" atLevel:@"INFO"];
+}
+
 - (void)log:(CDVInvokedUrlCommand*)command
 {
     NSString* callbackId = [command callbackId];

--- a/www/unifiedlogger.js
+++ b/www/unifiedlogger.js
@@ -26,9 +26,6 @@ var ULogger = {
      * instead of copying the template.
      */
     init: function() {
-        ULogger.log(ULogger.LEVEL_INFO, "finished init of native code", function(error) {
-            alert("Error "+error+" while initializing the unified logger");
-        });
         ULogger.db = window.sqlitePlugin.openDatabase({
             name: "loggerDB",
             location: 0,


### PR DESCRIPTION
And define the plugin to be loaded onload.
It is now started as part of the initial set of plugins, and doesn't take that long either.

2016-02-11 23:39:02.430 emission[49903:17135447] [CDVTimer][handleopenurl] 0.059009ms
2016-02-11 23:39:02.431 emission[49903:17135447] [CDVTimer][intentandnavigationfilter] 0.930965ms
2016-02-11 23:39:02.432 emission[49903:17135447] [CDVTimer][gesturehandler] 0.046968ms
2016-02-11 23:39:02.439 emission[49903:17135447] [CDVTimer][file] 7.634044ms
2016-02-11 23:39:02.462 emission[49903:17135447] [CDVTimer][splashscreen] 22.060990ms
2016-02-11 23:39:02.469 emission[49903:17135447] [CDVTimer][statusbar] 6.465018ms
2016-02-11 23:39:02.469 emission[49903:17135447] [CDVTimer][keyboard] 0.137031ms
2016-02-11 23:39:02.469 emission[49903:17135447] UnifiedLogger:pluginInitialize singleton -> initialize native DB
2016-02-11 23:39:02.471 emission[49903:17135447] [CDVTimer][unifiedlogger] 2.453983ms
2016-02-11 23:39:02.472 emission[49903:17135447] [CDVTimer][TotalPluginStartup] 41.270971ms

We could conceivably remove the db variable init from there and put it into the
actual functions and close them later. But it seems wasteful to open it for every transaction.
Let's wait and see how best to optimize that.
