### PR TITLE
Shorten the generated NSLog messages

### DIFF
--- a/src/ios/LocalNotificationManager.m
+++ b/src/ios/LocalNotificationManager.m
@@ -24,8 +24,10 @@ static int notificationCount = 0;
 }
 
 +(void)addNotification:(NSString *)notificationMessage showUI:(BOOL)showUI {
-    NSLog(@"Generating local notification with message %@", notificationMessage);
+    NSLog(@"%@", notificationMessage);
+    if (showUI) {
     notificationCount++;
+    }
     NSString* level = @"DEBUG";
     if (showUI) {
         level = @"INFO";


### PR DESCRIPTION
And only show a notification count based on the number of "showUI" logs
Otherwise we end up with a count of 10,000+
