### PR TITLE
Add in support for truncating the log

### DIFF
--- a/src/android/DatabaseLogHandler.java
+++ b/src/android/DatabaseLogHandler.java
@@ -56,7 +56,7 @@ public class DatabaseLogHandler extends SQLiteOpenHelper {
 
     public void log(String level, String message) {
         ContentValues cv = new ContentValues();
-        cv.put(KEY_TS, ((double)System.currentTimeMillis())/1000);
+        cv.put(KEY_TS, currentTimeSecs());
         cv.put(KEY_LEVEL, level);
         cv.put(KEY_MESSAGE, message);
         writeDB.insert(TABLE_LOG, null, cv);
@@ -64,5 +64,17 @@ public class DatabaseLogHandler extends SQLiteOpenHelper {
 
     public void clear() {
         writeDB.delete(TABLE_LOG, null, null);
+    }
+
+    public void truncateObsolete() {
+        // We somewhat arbitrarily decree that entries that are over a month old are obsolete
+        // This is to avoid unbounded growth of the log table
+        double monthAgoTs = currentTimeSecs() - 30 * 24 * 60 * 60; // 30 days * 24 hours * 60 minutes * 60 secs
+        log("INFO", "truncating obsolete entries before "+monthAgoTs);
+        writeDB.delete(TABLE_LOG, KEY_TS+" < "+monthAgoTs, null);
+    }
+
+    private double currentTimeSecs() {
+        return ((double)System.currentTimeMillis())/1000;
     }
 }

--- a/src/android/Log.java
+++ b/src/android/Log.java
@@ -37,12 +37,16 @@ public class Log {
             System.out.println("logger == null, lazily creating new logger");
             logger = new DatabaseLogHandler(ctxt);
         }
-        System.out.println("Returning logger "+logger);
+        // System.out.println("Returning logger "+logger);
         return logger;
     }
 
     public static void clear(Context ctxt) {
         getLogger(ctxt).clear();
+    }
+
+    public static void truncateObsolete(Context ctxt) {
+        getLogger(ctxt).truncateObsolete();
     }
 
     public static void log(Context ctxt, String level, String TAG, String message) {

--- a/src/android/UnifiedLogger.java
+++ b/src/android/UnifiedLogger.java
@@ -12,6 +12,7 @@ public class UnifiedLogger extends CordovaPlugin {
 
     protected void pluginInitialize() {
         Log.log(cordova.getActivity(), "INFO", "UnifiedLogger", "finished init of android native code");
+        Log.truncateObsolete(cordova.getActivity());
     }
 
     @Override

--- a/src/ios/BEMUnifiedLogger.m
+++ b/src/ios/BEMUnifiedLogger.m
@@ -10,6 +10,7 @@
     // copied over.
     NSLog(@"UnifiedLogger:pluginInitialize singleton -> initialize native DB");
     [[DBLogging database] log:@"finished init of iOS native code" atLevel:@"INFO"];
+    [[DBLogging database] truncateObsolete];
 }
 
 - (void)log:(CDVInvokedUrlCommand*)command

--- a/src/ios/DBLogging.h
+++ b/src/ios/DBLogging.h
@@ -17,5 +17,6 @@
 
 -(void)log:(NSString*) message atLevel:(NSString*)level;
 -(void)clear;
+-(void)truncateObsolete;
 
 @end


### PR DESCRIPTION
Right now, the truncation amount is a hardcoded constant that is the same on
both android and iOS (30 days). We can move this to a config option if we need
to.

As part of the change, did a bit of restructuring - creating a new method for
the current time secs in android and for executing an arbitrary delete command
in iOS.

Also removed a println statement that said "Returning logger" for every log
statement and cluttered up the logs.
