### PR TITLE
Unify the logger database as well

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,9 +20,6 @@
     <clobbers target="Logger" />
   </js-module>
 
-  <dependency id="cordova-sqlite-storage"
-             url="https://github.com/litehelpers/Cordova-sqlite-storage.git"/>
-
   <platform name="android">
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/Log.java
+++ b/src/android/Log.java
@@ -3,6 +3,9 @@ package edu.berkeley.eecs.emission.cordova.unifiedlogger;
 import android.content.Context;
 import android.os.Environment;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -43,6 +46,15 @@ public class Log {
 
     public static void clear(Context ctxt) {
         getLogger(ctxt).clear();
+    }
+
+    public static int getMaxIndex(Context ctxt) {
+        return getLogger(ctxt).getMaxIndex();
+    }
+
+    public static JSONArray getMessagesFromIndex(Context ctxt, int startIndex, int count)
+            throws JSONException {
+        return getLogger(ctxt).getMessagesFromIndex(startIndex, count);
     }
 
     public static void truncateObsolete(Context ctxt) {

--- a/src/android/UnifiedLogger.java
+++ b/src/android/UnifiedLogger.java
@@ -41,6 +41,30 @@ public class UnifiedLogger extends CordovaPlugin {
                 callbackContext.error(exceptionAsString);
             }
             return true;
+        } else if (action.equals("getMaxIndex")) {
+            try {
+                callbackContext.success(Log.getMaxIndex(cordova.getActivity()));
+            } catch (Exception e) {
+                e.printStackTrace();
+                StringWriter sw = new StringWriter();
+                e.printStackTrace(new PrintWriter(sw));
+                String exceptionAsString = sw.toString();
+                callbackContext.error(exceptionAsString);
+            }
+            return true;
+        } else if (action.equals("getMessagesFromIndex")) {
+            try {
+                int startIndex = data.getInt(0);
+                int count = data.getInt(1);
+                callbackContext.success(Log.getMessagesFromIndex(cordova.getActivity(), startIndex, count));
+            } catch (Exception e) {
+                e.printStackTrace();
+                StringWriter sw = new StringWriter();
+                e.printStackTrace(new PrintWriter(sw));
+                String exceptionAsString = sw.toString();
+                callbackContext.error(exceptionAsString);
+            }
+            return true;
         } else {
             return false;
         }

--- a/src/ios/BEMUnifiedLogger.m
+++ b/src/ios/BEMUnifiedLogger.m
@@ -36,11 +36,52 @@
 
 - (void)clear:(CDVInvokedUrlCommand*)command
 {
-
     NSString* callbackId = [command callbackId];
 
     @try {
         [[DBLogging database] clear];
+    }
+    @catch (NSException* e) {
+        NSString* msg = [NSString stringWithFormat: @"While clearing DB, error %@", e];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void)getMaxIndex:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    
+    @try {
+        int maxInt = [[DBLogging database] getMaxIndex];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsInt: maxInt];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException* e) {
+        NSString* msg = [NSString stringWithFormat: @"While clearing DB, error %@", e];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void)getMessagesFromIndex:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    
+    @try {
+        int startIndex = [[[command arguments] objectAtIndex:0] intValue];
+        int count = [[[command arguments] objectAtIndex:1] intValue];
+        NSArray* resultArray = [[DBLogging database] getMessagesFromIndex:startIndex forCount:count];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultArray];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
     }
     @catch (NSException* e) {
         NSString* msg = [NSString stringWithFormat: @"While clearing DB, error %@", e];

--- a/src/ios/DBLogging.h
+++ b/src/ios/DBLogging.h
@@ -18,5 +18,7 @@
 -(void)log:(NSString*) message atLevel:(NSString*)level;
 -(void)clear;
 -(void)truncateObsolete;
+-(int)getMaxIndex;
+-(NSArray*) getMessagesFromIndex:(int)startIndex forCount:(int)count;
 
 @end

--- a/www/unifiedlogger.js
+++ b/www/unifiedlogger.js
@@ -44,13 +44,17 @@ var ULogger = {
      *    The expectation is that it takes a single argument.
      */
 
-    log: function (level, message, errorCallback) {
+    log: function (level, message) {
         console.log(level + ":" + message);
-        exec(null, errorCallback, "UnifiedLogger", "log", [level, message]);
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UnifiedLogger", "log", [level, message]);
+        });
     },
 
-    clearAll: function(successCallback, errorCallback) {
-        exec(null, errorCallback, "UnifiedLogger", "clear", []);
+    clearAll: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UnifiedLogger", "clear", []);
+        });
     },
 
     /*
@@ -61,54 +65,15 @@ var ULogger = {
      * we have started reading the database. This function returns the max
      * index, to be passed to the getMessagesFromIndex function.
      */
-    getMaxIndex: function (successCallback, errorCallback) {
-        ULogger.db().readTransaction(function(tx) {
-            var maxIndexQuery = "SELECT MAX(ID) FROM "+ULogger.LOG_TABLE;
-            console.log("About to execute query "+maxIndexQuery+" against "+ULogger.LOG_TABLE);
-            tx.executeSql(maxIndexQuery,
-                [],
-                function(tx, data) {
-                    if (data.rows.length == 0) {
-                        errorCallback("no max index returned - are there any index values? unable to retrieve logs")
-                    } else {
-                        var maxIndex = data.rows.item(0)["MAX(ID)"];
-                        successCallback(maxIndex);
-                    }
-                }, function(e, response) {
-                    errorCallback(response);
-                    return false;
-                })
-        }, function(error) {
-            errorCallback(error);
+    getMaxIndex: function () {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UnifiedLogger", "getMaxIndex", []);
         });
     },
 
-    getMessagesFromIndex: function (startIndex, count, successCallback, errorCallback) {
-        ULogger.db().readTransaction(function(tx) {
-            var selQuery = "SELECT * FROM "+ULogger.LOG_TABLE+
-                           " WHERE "+ULogger.KEY_ID+" < "+startIndex+
-                           " ORDER BY "+ULogger.KEY_ID+" DESC LIMIT "+count;
-            // Log statements in the logger don't go into the logger.
-            // No infinite loop here!
-            console.log("About to execute query "+selQuery+" against "+ULogger.LOG_TABLE);
-            tx.executeSql(selQuery,
-                [],
-                function(tx, data) {
-                    var resultList = [];
-                    console.log("Result has "+data.rows.length+" rows");
-                    for (i = 0; i < data.rows.length; i++) {
-                        var currRow = data.rows.item(i);
-                        currRow.fmt_time = moment.unix(currRow.ts).format("llll");
-                        resultList.push(currRow);
-                    }
-                    successCallback(resultList);
-                },
-                function(e, response) {
-                    errorCallback(response);
-                    return false;
-                });
-        }, function(error) {
-            errorCallback(error);
+    getMessagesFromIndex: function (startIndex, count) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UnifiedLogger", "getMessagesFromIndex", [startIndex, count]);
         });
     },
 


### PR DESCRIPTION
In https://github.com/e-mission/cordova-usercache/pull/20, and follow on commits
https://github.com/e-mission/cordova-usercache/pull/21 and
https://github.com/e-mission/cordova-usercache/pull/22, we ensured that all
accesses to the usercache went through the same handle.

It looks like sqlite on android (and maybe iOS) doesn't really support
multi-threaded access to the same database because it throws a database locked
error instead.
https://github.com/e-mission/e-mission-data-collection/issues/124

We haven't run into this as much with the logs because accessing the logs is
hidden in the developer zone, but it could happen! So let's unify accesses to
the logs as well. We should be able to remove the sqlite plugin once we remove
the stats code.
