### PR TITLE
Ensure that the local alerts generated on android disappers on click

### DIFF
--- a/src/android/NotificationHelper.java
+++ b/src/android/NotificationHelper.java
@@ -62,6 +62,7 @@ public class NotificationHelper {
 		 * TODO: Decide what level API we want to support, and whether we want a more comprehensive activity.
 		 */
 		builder.setContentIntent(intent);
+		builder.setAutoCancel(true);
 
 		NotificationManager nMgr =
 				(NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);


### PR DESCRIPTION
Otherwise, they launch the app but do not do anything else. Otherwise it is
confusing because the user percieves that the app is constantly reporting this
error.