### PR TITLE
Add a new `showNotificationAfterSecs` method

### DIFF
--- a/src/ios/LocalNotificationManager.h
+++ b/src/ios/LocalNotificationManager.h
@@ -14,5 +14,6 @@
 +(void)addNotification:(NSString*) notificationMessage;
 +(void)addNotification:(NSString*) notificationMessage showUI:(BOOL)showUI;
 +(void)showNotification:(NSString*) notificationMessage;
++(void)showNotificationAfterSecs:(NSString *)notificationMessage secsLater:(int)secsLater;
 
 @end

--- a/src/ios/LocalNotificationManager.m
+++ b/src/ios/LocalNotificationManager.m
@@ -41,6 +41,7 @@ static int notificationCount = 0;
 }
 
 +(void)showNotification:(NSString *)notificationMessage {
+    [LocalNotificationManager addNotification:notificationMessage];
     notificationCount++;
         UILocalNotification *localNotif = [[UILocalNotification alloc] init];
         if (localNotif) {
@@ -49,5 +50,17 @@ static int notificationCount = 0;
             [[UIApplication sharedApplication] presentLocalNotificationNow:localNotif];
         }
     }
+
++(void)showNotificationAfterSecs:(NSString *)notificationMessage secsLater:(int)secsLater {
+    [LocalNotificationManager addNotification:notificationMessage];
+    notificationCount++;
+    UILocalNotification *localNotif = [[UILocalNotification alloc] init];
+    if (localNotif) {
+        localNotif.alertBody = notificationMessage;
+        localNotif.applicationIconBadgeNumber = notificationCount;
+        localNotif.fireDate = [NSDate dateWithTimeIntervalSinceNow:secsLater];
+        [[UIApplication sharedApplication] scheduleLocalNotification:localNotif];
+    }
+}
 
 @end


### PR DESCRIPTION
to allow the notification on app termination to appear after a minute.
This ensures that the notification is not lost while the app is closed.
This is needed for https://github.com/e-mission/e-mission-data-collection/pull/144/commits/af7f1c5ae1ea0b4a15d50123ae8e476e808c7c34