### PR TITLE
Switch to new authentication library and sign in screen from google

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.unifiedlogger"
-        version="0.0.1">
+        version="1.0.0">
 
   <name>UnifiedLogger</name>
   <description>Log messages from both native code and javacript. Since this is

--- a/src/ios/LocalNotificationManager.h
+++ b/src/ios/LocalNotificationManager.h
@@ -14,6 +14,7 @@
 +(void)addNotification:(NSString*) notificationMessage;
 +(void)addNotification:(NSString*) notificationMessage showUI:(BOOL)showUI;
 +(void)showNotification:(NSString*) notificationMessage;
-+(void)showNotificationAfterSecs:(NSString *)notificationMessage secsLater:(int)secsLater;
++(void)showNotificationAfterSecs:(NSString *)notificationMessage withUserInfo:(NSDictionary*)userInfo
+                                                                    secsLater:(int)secsLater;
 
 @end

--- a/src/ios/LocalNotificationManager.m
+++ b/src/ios/LocalNotificationManager.m
@@ -51,13 +51,17 @@ static int notificationCount = 0;
         }
     }
 
-+(void)showNotificationAfterSecs:(NSString *)notificationMessage secsLater:(int)secsLater {
++(void)showNotificationAfterSecs:(NSString *)notificationMessage withUserInfo:(NSDictionary*)userInfo
+                                                                    secsLater:(int)secsLater {
     [LocalNotificationManager addNotification:notificationMessage];
     notificationCount++;
     UILocalNotification *localNotif = [[UILocalNotification alloc] init];
     if (localNotif) {
         localNotif.alertBody = notificationMessage;
-        localNotif.applicationIconBadgeNumber = notificationCount;
+        // localNotif.applicationIconBadgeNumber = notificationCount;
+        if (userInfo != NULL) {
+            localNotif.userInfo = userInfo;
+        }
         localNotif.fireDate = [NSDate dateWithTimeIntervalSinceNow:secsLater];
         [[UIApplication sharedApplication] scheduleLocalNotification:localNotif];
     }


### PR DESCRIPTION
Supports the changes required by
https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html

Most of the changes are in
e-mission/cordova-jwt-auth#13

The changes here merely support those.