### PR TITLE
Ensure that the userInfo for visible notifications is always non-null

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.unifiedlogger"
-        version="1.0.0">
+        version="1.0.1">
 
   <name>UnifiedLogger</name>
   <description>Log messages from both native code and javacript. Since this is

--- a/src/ios/LocalNotificationManager.m
+++ b/src/ios/LocalNotificationManager.m
@@ -44,6 +44,7 @@ static int notificationCount = 0;
     [LocalNotificationManager addNotification:notificationMessage];
     notificationCount++;
         UILocalNotification *localNotif = [[UILocalNotification alloc] init];
+        localNotif.userInfo = @{};
         if (localNotif) {
             localNotif.alertBody = notificationMessage;
             localNotif.applicationIconBadgeNumber = notificationCount;
@@ -61,6 +62,8 @@ static int notificationCount = 0;
         // localNotif.applicationIconBadgeNumber = notificationCount;
         if (userInfo != NULL) {
             localNotif.userInfo = userInfo;
+        } else {
+            localNotif.userInfo = @{};
         }
         localNotif.fireDate = [NSDate dateWithTimeIntervalSinceNow:secsLater];
         [[UIApplication sharedApplication] scheduleLocalNotification:localNotif];


### PR DESCRIPTION
Otherwise, on older iOS versions, you get this crash
https://github.com/e-mission/e-mission-phone/issues/228