### PR TITLE
Add a new method to allow us to address plugin compatiblity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-unifiedlogger"
-        version="1.3.3">
+        version="1.3.4">
 
   <name>UnifiedLogger</name>
   <description>Log messages from both native code and javacript. Since this is


### PR DESCRIPTION
Add a new method (`schedulePluginCompatibleNotification`) to create (or
schedule) a new plugin-compatible notification. This means that quite a lot of
the notification parameters are stored in the notification config.

Then, schedule the method using the local notification plugin's Manager,
similar to the existing code in transition notify plugin. This ensures that the
javascript callback is invoked correctly.

+ allows callers to supply a title instead of always using the app name.
 Use null defaults for most all sites, but use separate title and text for the
    newly generated "open app status" notification.

+ bump up version number to reflect the new functionality