### PR TITLE
Schedule plugin compatible notifications by inserting JSON messages i…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-unifiedlogger"
-        version="1.3.4">
+        version="1.3.5">
 
   <name>UnifiedLogger</name>
   <description>Log messages from both native code and javacript. Since this is

--- a/src/ios/LocalNotificationManager.h
+++ b/src/ios/LocalNotificationManager.h
@@ -11,10 +11,11 @@
 @interface LocalNotificationManager : NSObject
 
 +(void)clearNotifications;
++(void)cancelNotification:(NSNumber*) id;
 +(void)addNotification:(NSString*) notificationMessage;
 +(void)addNotification:(NSString*) notificationMessage showUI:(BOOL)showUI;
 +(void)showNotification:(NSString*) notificationMessage;
 +(void)showNotificationAfterSecs:(NSString *)notificationMessage withUserInfo:(NSDictionary*)userInfo
                                                                     secsLater:(int)secsLater;
-
++(void)schedulePluginCompatibleNotification:(NSDictionary*) currNotifyConfig withNewData:(NSDictionary*)newData;
 @end


### PR DESCRIPTION
…nto the execution queue

This is required because the `AppLocalNotification` class on iOS, unlike
android does not have a public implementation of the schedule method and even
the private method wraps `runInBackground`.

So we create a message that corresponds to the call we want to make and execute
it through the existing command queue.

We also tried calling
`[AppLocalNotification schedule:command]` directly, but then the
`commandDelegate` in the `schedule` implementation is NULL so the actual
notification is never scheduled.

TODO: Also experiment with calling it through a category, although there isn't
very much code we can reuse. Alternatively, pull out the "execute via plugin"
functionality into a separate module so we can potentially reuse it elsewhere.

Equivalent PR from android:
https://github.com/e-mission/cordova-unified-logger/pull/35